### PR TITLE
use renamed sleep function in fictrac.cpp

### DIFF
--- a/exec/fictrac.cpp
+++ b/exec/fictrac.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
         if (!_active) {
             tracker->terminate();
         }
-        sleep(250);
+        ficsleep(250);
     }
 
     /// Save the eventual template to disk.
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     tracker.reset();
 
     /// Wait a bit before exiting...
-    sleep(250);
+    ficsleep(250);
 
     //PRINT("\n\nHit ENTER to exit..");
     //getchar_clean();


### PR DESCRIPTION
Commits 9b143c3d5a6679aa4b82862a691c11979c6ccacb and 2a8485c882fabd9008868735de80af3910c63f16 fix an issue with an ambiguous function name while `fictrac.cpp` still uses the old name. This commit fixes the issue.